### PR TITLE
Ensure we set a default timeout of 10s

### DIFF
--- a/lib/zendesk_api/configuration.rb
+++ b/lib/zendesk_api/configuration.rb
@@ -59,6 +59,7 @@ module ZendeskAPI
           :user_agent => "ZendeskAPI Ruby #{ZendeskAPI::VERSION}"
         },
         :request => {
+          :timeout => 10,
           :open_timeout => 10
         },
         :url => @url


### PR DESCRIPTION
To ensure we are never waiting indefinitely for an API call.